### PR TITLE
webxdc import/export

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -1,7 +1,6 @@
 //@ts-check
 /** @typedef {import('./webxdc').Webxdc} Webxdc */
-
-/** @typedef {{id: any, color: string, startDate, endDate, }} CalEvent */
+/** @typedef {import('./types').CalEvent} CalEvent */
 
 /**
  * @param {HTMLElement} el
@@ -174,7 +173,6 @@ var cal = {
 		document.getElementById("evt-close").onclick = cal.close;
 		cal.btnSave.onclick = cal.save;
 		cal.events = [];
-		events = cal.events; //link to the export var
 		cal.eventsView = document.getElementById("eventsDay");
 		cal.eventsView.classList.add("ninja");
 		cal.evCards = document.getElementById("evt-cards");
@@ -806,7 +804,7 @@ var cal = {
 		//check if id is one or more events
 		if (id === undefined) {
 			cal.getExport.classList.remove("ninja");
-			document.querySelector("#exportData").textContent = setClipboard();
+			document.querySelector("#exportData").textContent = makeString(cal.events);
 			document.querySelector("#exportTitle").textContent = "";
 		} else {
 			let event = cal.events.filter((ev) => {

--- a/calendar.js
+++ b/calendar.js
@@ -190,7 +190,9 @@ var cal = {
 		cal.calendar.classList.add("ninja");
 		cal.import = document.getElementById("evt-import");
 		cal.import.onclick = () => {
-			getClipboard(cal.importArea.value);
+			const events = parseIcsToJSON(cal.importArea.value)
+			console.log("import" + events);
+			parseJSONToWebxdcUpdate(events);
 			cal.closeImport();
 		};
 		cal.importFromFile = document.getElementById("evt-import-from-dc");

--- a/calendar.js
+++ b/calendar.js
@@ -817,7 +817,7 @@ var cal = {
 			cal.eventsView.classList.add("ninja");
 			cal.getExport.classList.remove("ninja");
 			document.querySelector("#exportData").textContent = icsString;
-			if (event.length == 1) {
+			if (event.length === 1) {
 				document.querySelector("#exportTitle").textContent = event[0].data;
 			}
 		}

--- a/calendar.js
+++ b/calendar.js
@@ -1,5 +1,8 @@
 //@ts-check
 /** @typedef {import('./webxdc').Webxdc} Webxdc */
+
+/** @typedef {{id: any, color: string, startDate, endDate, }} CalEvent */
+
 /**
  * @param {HTMLElement} el
  */
@@ -111,6 +114,7 @@ var cal = {
 	container: null,
 	hfTxt: null, //event form
 	btnSave: null,
+	/** @type {CalEvent[]} */
 	events: null,
 	eventsView: null,
 	evCards: null,
@@ -281,7 +285,7 @@ var cal = {
 		// (B3) APPEND MONTHS SELECTOR
 		for (let i = 0; i < 12; i++) {
 			let opt = document.createElement("option");
-			opt.value = i;
+			opt.value = String(i);
 			opt.textContent = cal.mName[i];
 			if (i == cal.nowMth) {
 				opt.selected = true;
@@ -293,8 +297,8 @@ var cal = {
 		// Set to 30 years range. Change this as you like.
 		for (let i = cal.nowYear - 30; i <= cal.nowYear + 30; i++) {
 			let opt = document.createElement("option");
-			opt.value = i;
-			opt.textContent = i;
+			opt.value = String(i);
+			opt.textContent = String(i);
 			if (i == cal.nowYear) {
 				opt.selected = true;
 			}
@@ -449,7 +453,7 @@ var cal = {
 				}
 				const dayEl = document.createElement('div');
 				dayEl.classList.add("dd");
-				dayEl.textContent = day;
+				dayEl.textContent = String(day);
 				cCell.appendChild(dayEl);
 
 				//retrieve events for this day
@@ -599,6 +603,13 @@ var cal = {
 	},
 
 	// GET ALL EVENTS FROM A DAY
+	/**
+	 * 
+	 * @param {number} year 
+	 * @param {number} month 
+	 * @param {number} day 
+	 * @returns {CalEvent[]}
+	 */
 	getEvents: (year, month, day) => {
 		var events = cal.events.filter((event) => {
 			let startDate = new Date(event.startDate);
@@ -640,7 +651,7 @@ var cal = {
 			dateSt = new Date(cal.importEventObj.startDate);
 			dateEnd = new Date(cal.importEventObj.endDate);
 			data = cal.importEventObj.summary;
-			color = "black";
+			color =  cal.importEventObj.color;
 			info =
 				window.webxdc.selfName +
 				" imported an event " +

--- a/calendar.js
+++ b/calendar.js
@@ -805,9 +805,9 @@ var cal = {
 		// navigator.clipboard.writeText(
 		// 	document.querySelector("#exportData").textContent
 		// );
-		const temp = document.createElement("input");
+		const temp = document.createElement("textarea");
 		const text = document.getElementById("exportData").textContent;
-		temp.setAttribute("value", text);
+		temp.innerHTML = text;
 		document.body.appendChild(temp);
 		temp.select();
 		document.execCommand("copy");

--- a/calendar.js
+++ b/calendar.js
@@ -831,10 +831,13 @@ var cal = {
 		const data = document.getElementById("exportData").textContent;
 		const title = document.getElementById("exportTitle").textContent;
 		const file = new File([data], "event.ics", {
-			type: "text/calendar",
+   			type: "text/calendar",
 		});
 		try {
-			await window.webxdc.sendToChat({ file, text: title })
+			await window.webxdc.sendToChat({
+				file: { name: file.name, blob: file },
+				text: title,
+			});
 		} catch (error) {
 			console.error("export failed", error);
 		}

--- a/calendar.js
+++ b/calendar.js
@@ -1,3 +1,5 @@
+//@ts-check
+/** @typedef {import('./webxdc').Webxdc} Webxdc */
 /**
  * @param {HTMLElement} el
  */
@@ -135,6 +137,7 @@ var cal = {
 	importEventObj: undefined,
 	getExport: null,
 	copyBtn: null,
+	exportToDCBtn: null,
 	multiDayCheck: null,
 	multiDayForm: null,
 	recurringCheck: null,
@@ -218,6 +221,8 @@ var cal = {
 		cal.getExport = document.getElementById("getExport");
 		cal.copyBtn = document.getElementById("i-clipboard");
 		cal.copyBtn.onclick = cal.copyExporter;
+		cal.exportToDCBtn = document.getElementById("export-to-dc");
+		cal.exportToDCBtn.onclick = cal.chatExporter;
 		cal.multiDayCheck = document.getElementById("multi-day");
 		cal.multiDayCheck.onchange = (ev) => {
 			//set the default date in form
@@ -788,6 +793,7 @@ var cal = {
 		if (id === undefined) {
 			cal.getExport.classList.remove("ninja");
 			document.querySelector("#exportData").textContent = setClipboard();
+			document.querySelector("#exportTitle").textContent = "";
 		} else {
 			let event = cal.events.filter((ev) => {
 				return Number.parseInt(ev.id) === Number.parseInt(id);
@@ -797,6 +803,9 @@ var cal = {
 			cal.eventsView.classList.add("ninja");
 			cal.getExport.classList.remove("ninja");
 			document.querySelector("#exportData").textContent = icsString;
+			if (event.length == 1) {
+				document.querySelector("#exportTitle").textContent = event[0].data;
+			}
 		}
 	},
 
@@ -813,6 +822,23 @@ var cal = {
 		document.execCommand("copy");
 		document.body.removeChild(temp);
 		cal.copyBtn.style.color = "#FAD02C";
+	},
+
+	chatExporter: async () => {
+		const data = document.getElementById("exportData").textContent;
+		const title = document.getElementById("exportTitle").textContent;
+		const file = new File([data], "event.ics", {
+			type: "text/calendar",
+		});
+		try {
+			if (await window.webxdc.sendToChat({ file, text: title })) {
+				console.info("exported successfully");
+			} else {
+				console.info("export was aborted by user");
+			}
+		} catch (error) {
+			console.error("export failed", error);
+		}
 	},
 };
 window.addEventListener("load", cal.init);

--- a/calendar.js
+++ b/calendar.js
@@ -124,6 +124,7 @@ var cal = {
 	touchendX: 0,
 	calendar: null,
 	import: null,
+	importFromFile: null,
 	export: null,
 	importScreen: null,
 	importScrBtn: null,
@@ -190,6 +191,8 @@ var cal = {
 			getClipboard(cal.importArea.value);
 			cal.closeImport();
 		};
+		cal.importFromFile = document.getElementById("evt-import-from-dc");
+		cal.importFromFile.onclick = cal.chatImporter
 		cal.export = document.getElementById("evt-export");
 		cal.export.onclick = () => {
 			cal.exporter();
@@ -840,5 +843,18 @@ var cal = {
 			console.error("export failed", error);
 		}
 	},
+
+	chatImporter: async () => {
+		const [file] = await window.webxdc.importFiles({
+			mimeTypes: ["text/calendar"],
+			extentions: [".ics"],
+		});
+		const text = await file.text();
+		const events = parseIcsToJSON(text);
+		console.log(events);
+		parseJSONToWebxdcUpdate(events);
+		cal.closeImport();
+	}
+	
 };
 window.addEventListener("load", cal.init);

--- a/calendar.js
+++ b/calendar.js
@@ -834,11 +834,7 @@ var cal = {
 			type: "text/calendar",
 		});
 		try {
-			if (await window.webxdc.sendToChat({ file, text: title })) {
-				console.info("exported successfully");
-			} else {
-				console.info("export was aborted by user");
-			}
+			await window.webxdc.sendToChat({ file, text: title })
 		} catch (error) {
 			console.error("export failed", error);
 		}

--- a/ics-json.js
+++ b/ics-json.js
@@ -49,6 +49,7 @@ function parseIcsToJSON(icsData) {
 	const ALARM = "VALARM";
 	const UID = "UID";
 	const TZID = "TZID";
+	const X_COLOR = "X-CALENDAR-XDC-COLOR"
 
 	const keyMap = {
 		[UID]: "uid",
@@ -58,6 +59,7 @@ function parseIcsToJSON(icsData) {
 		[SUMMARY]: "summary",
 		[LOCATION]: "location",
 		[TZID]: "timeZone",
+		[X_COLOR]: "color"
 	};
 
 	const clean = (string) => unescape(string).trim();
@@ -127,6 +129,8 @@ function parseIcsToJSON(icsData) {
 				break;
 			case LOCATION:
 				currentObj[keyMap[LOCATION]] = clean(value);
+			case X_COLOR:
+				currentObj[keyMap[X_COLOR]] = clean(value);
 			default:
 				continue;
 		}

--- a/ics-json.js
+++ b/ics-json.js
@@ -1,7 +1,9 @@
 //get text from the clipboard
 function getClipboard(text) {
 	if (text !== "") {
-		console.log(parseIcsToJSON(text));
+		const events = parseIcsToJSON(text)
+		console.log(events);
+		parseJSONToWebxdcUpdate(events);
 	} else {
 		console.log("No text on the clipboard!");
 	}
@@ -129,12 +131,12 @@ function parseIcsToJSON(icsData) {
 				continue;
 		}
 	}
-	parseJSONToWebxdcUpdate(array);
+	return array
 }
 
-function parseJSONToWebxdcUpdate(JSON) {
-	for (const evt in JSON) {
-		cal.importEventObj = JSON[evt];
+function parseJSONToWebxdcUpdate(events) {
+	for (const evt in events) {
+		cal.importEventObj = events[evt];
 		cal.save();
 	}
 	cal.importEventObj = undefined;

--- a/ics-json.js
+++ b/ics-json.js
@@ -1,14 +1,3 @@
-//get text from the clipboard
-function getClipboard(text) {
-	if (text !== "") {
-		const events = parseIcsToJSON(text)
-		console.log(events);
-		parseJSONToWebxdcUpdate(events);
-	} else {
-		console.log("No text on the clipboard!");
-	}
-}
-
 //transform ics dates to Date timestamps
 //ics dates are YYYYMMDDTHHmmSS format
 function calenDate(icalStr, timezone) {

--- a/index.html
+++ b/index.html
@@ -118,11 +118,13 @@
 				<button class="eventBtn" id="evt-export">Export data to ICS file</button>
 			</div>
 			<div id="getExport" class="block bottomMargin">
+				<h2 id="exportTitle"></h2>
 				<pre id="exportData"></pre>
 				<svg id="i-clipboard" viewBox="0 0 32 32" width="27" height="27" fill="none"
 					stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3">
 					<path d="M12 2 L12 6 20 6 20 2 12 2 Z M11 4 L6 4 6 30 26 30 26 4 21 4" />
 				</svg>
+				<button id="export-to-dc" class="eventBtn">Export to Chat</button>
 			</div>
 		</div>
 

--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
 					ICS format</p>
 				<textarea id="importArea" placeholder="ICS format input..."></textarea>
 				<button class="eventBtn" id="evt-import">Import ICS data</button>
+				<button class="eventBtn" id="evt-import-from-dc">Import ICS File</button>
 				<button class="eventBtn" id="evt-export">Export data to ICS file</button>
 			</div>
 			<div id="getExport" class="block bottomMargin">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 
 		<!-- PERIOD SELECTOR -->
 		<div id="cal">
-			<button style="display: none;" class="import" id="evt-imp-exp"><svg id="i-export" viewBox="0 0 32 32" width="20" height="20"
+			<button class="import" id="evt-imp-exp"><svg id="i-export" viewBox="0 0 32 32" width="20" height="20"
 					fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5">
 					<path d="M28 22 L28 30 4 30 4 22 M16 4 L16 24 M8 12 L16 4 24 12" />
 				</svg> Export/Import</button>

--- a/json-ics.js
+++ b/json-ics.js
@@ -67,6 +67,8 @@ function makeString(events) {
 				SEPARATOR +
 				`LOCATION:${events[i][location] ? events[i].location : ""}` +
 				SEPARATOR +
+				`X-CALENDAR-XDC-COLOR:${escape(events[i].color)}` +
+				SEPARATOR +
 				"END:VEVENT" +
 				SEPARATOR;
 		

--- a/json-ics.js
+++ b/json-ics.js
@@ -1,29 +1,10 @@
-let events;
 const SEPARATOR = "\r\n";
 // const SEPARATOR = "\\n"; //to import in Outlook calendar
 
-// /**
-//  * Write ICS to a file in the current directory called event.ics
-//  * @param {Date} start - Starting time of the event.
-//  * @param {Date} end - Ending time of the event.
-//  * @param {String} title - Title of the event.
-//  * @param {String} location - Location of the event.
-//  */
-// function makeICS(start, end, title = "", location = "") {
-// 	fs.writeFile(
-// 		__dirname + "/calendar-events.ics",
-// 		makeString(startDate, endDate, title, location),
-// 		function (err) {
-// 			if (err) {
-// 				return console.log(err);
-// 			}
-// 		}
-// 	);
-// }
 
 /**
  * Output ICS as a string
- * @param {Array} events - The array of events
+ * @param {(import('./types').CalEvent)[]} events - The array of events
  * @returns {String} String representation of the ICS events
  */
 function makeString(events) {
@@ -40,13 +21,13 @@ function makeString(events) {
 		" calendar" +
 		SEPARATOR;
 		let lastID = 0;
-	for (const i in events) {
+	for (const event of events) {
 		//if is the same ID is a multi-day event, so skip iteration
-		if (Number.parseInt(events[i].id) === Number.parseInt(lastID)) continue;
+		if (Number.parseInt(event.id) === Number.parseInt(lastID)) continue;
 		//compound the event in ics format
-			lastID = events[i].id;
-			let dateStart = new Date(events[i].startDate);
-			let dateEnd = new Date(events[i].endDate);
+			lastID = event.id;
+			let dateStart = new Date(event.startDate);
+			let dateEnd = new Date(event.endDate);
 			icsString +=
 				"BEGIN:VEVENT" +
 				SEPARATOR +
@@ -61,13 +42,13 @@ function makeString(events) {
 				//maybe do something with this longer than a day events later
 				`DTEND;VALUE=DATE:${toDateTime(dateEnd)}` +
 				SEPARATOR +
-				`SUMMARY:${events[i].data}` +
+				`SUMMARY:${event.data}` +
 				SEPARATOR +
-				`DESCRIPTION:${events[i].data}` +
+				`DESCRIPTION:${event.data}` +
 				SEPARATOR +
-				`LOCATION:${events[i][location] ? events[i].location : ""}` +
+				`LOCATION:${event[location] ? event.location : ""}` +
 				SEPARATOR +
-				`X-CALENDAR-XDC-COLOR:${escape(events[i].color)}` +
+				`X-CALENDAR-XDC-COLOR:${escape(event.color)}` +
 				SEPARATOR +
 				"END:VEVENT" +
 				SEPARATOR;
@@ -82,11 +63,4 @@ function toDateTime(date) {
 	const isoString = date.toISOString();
 	const formattedString = isoString.replace(/[-:.]/g, "");
 	return formattedString.substring(0, formattedString.length - 4) + "Z";
-}
-
-// Set info in the clipboard
-function setClipboard() {
-	let data = makeString(events);
-	console.log(data);
-	return data;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,9 @@
+export type CalEvent = {
+  id: any;
+  color: string;
+  startDate;
+  endDate;
+  /** used for summary and for description */
+  data: string;
+  location;
+};

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,4 +6,5 @@ export type CalEvent = {
   /** used for summary and for description */
   data: string;
   location;
+  creator: string;
 };

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -1,102 +1,119 @@
 //@ts-check
 
 type SendingStatusUpdate<T> = {
-    /** the payload, deserialized json:
-     * any javascript primitive, array or object. */
-    payload: T;
-    /** optional, short, informational message that will be added to the chat,
-     * eg. "Alice voted" or "Bob scored 123 in MyGame";
-     * usually only one line of text is shown,
-     * use this option sparingly to not spam the chat. */
-    info?: string;
-    /** optional, if the Webxdc creates a document, you can set this to the name of the document;
-     * do not set if the Webxdc does not create a document */
-    document?: string;
-    /** optional, short text, shown beside the icon;
-     * it is recommended to use some aggregated value,
-     * eg. "8 votes", "Highscore: 123" */
-    summary?: string;
-  };
-  
-  type ReceivedStatusUpdate<T> = {
-    /** the payload, deserialized json */
-    payload: T;
-    /** the serial number of this update. Serials are larger than 0 and newer serials have higher numbers */
-    serial: number;
-    /** the maximum serial currently known */
-    max_serial: number;
-    /** optional, short, informational message. */
-    info?: string;
-    /** optional, if the Webxdc creates a document, this is the name of the document;
-     * not set if the Webxdc does not create a document */
-    document?: string;
-    /** optional, short text, shown beside the webxdc's icon. */
-    summary?: string;
-  };
-  
-  type sendOptions =
-    | {
-        file: File;
-        text?: string;
-      }
-    | {
-        file?: File;
-        text: string;
-      };
-  
-  interface Webxdc<T> {
-    /** Returns the peer's own address.
-     *  This is esp. useful if you want to differ between different peers - just send the address along with the payload,
-     *  and, if needed, compare the payload addresses against selfAddr() later on. */
-    selfAddr: string;
-    /** Returns the peer's own name. This is name chosen by the user in their settings, if there is nothing set, that defaults to the peer's address. */
-    selfName: string;
-    /**
-     * set a listener for new status updates.
-     * The "serial" specifies the last serial that you know about (defaults to 0).
-     * Note that own status updates, that you send with {@link sendUpdate}, also trigger this method
-     * @returns promise that resolves when the listener has processed all the update messages known at the time when `setUpdateListener` was called.
-     * */
-    setUpdateListener(
-      cb: (statusUpdate: ReceivedStatusUpdate<T>) => void,
-      serial?: number
-    ): Promise<void>;
-    /**
-     * @deprecated See {@link setUpdateListener|`setUpdateListener()`}.
-     */
-    getAllUpdates(): Promise<ReceivedStatusUpdate<T>[]>;
-    /**
-     * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
-     * @param update status update to send
-     * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
-     */
-    sendUpdate(update: SendingStatusUpdate<T>, description: string): void;
-    /**
-     * Send a message with file, text or both to a chat.
-     * Asks user to what Chat to send the message to.
-     * Always exits the xdc, please save your app state before calling this function
-     * @param content
-     * @returns returns a promise that never resolves (because the xdc closes), but is rejected on error.
-     */
-    sendToChat(content: sendOptions): Promise<void>;
-    /**
-     * TODO
-     */
-    importFiles(filters: {
-      mimeTypes?: string[];
-      extentions?: string[];
-      /** false by default, whether to allow multiple files to be selected */
-      multiple?: boolean;
-    }): Promise<File[]>;
-  }
-  
-  ////////// ANCHOR: global
-  declare global {
-    interface Window {
-      webxdc: Webxdc<any>;
+  /** the payload, deserialized json:
+   * any javascript primitive, array or object. */
+  payload: T;
+  /** optional, short, informational message that will be added to the chat,
+   * eg. "Alice voted" or "Bob scored 123 in MyGame";
+   * usually only one line of text is shown,
+   * use this option sparingly to not spam the chat. */
+  info?: string;
+  /** optional, if the Webxdc creates a document, you can set this to the name of the document;
+   * do not set if the Webxdc does not create a document */
+  document?: string;
+  /** optional, short text, shown beside the icon;
+   * it is recommended to use some aggregated value,
+   * eg. "8 votes", "Highscore: 123" */
+  summary?: string;
+};
+
+type ReceivedStatusUpdate<T> = {
+  /** the payload, deserialized json */
+  payload: T;
+  /** the serial number of this update. Serials are larger than 0 and newer serials have higher numbers */
+  serial: number;
+  /** the maximum serial currently known */
+  max_serial: number;
+  /** optional, short, informational message. */
+  info?: string;
+  /** optional, if the Webxdc creates a document, this is the name of the document;
+   * not set if the Webxdc does not create a document */
+  document?: string;
+  /** optional, short text, shown beside the webxdc's icon. */
+  summary?: string;
+};
+
+export type XDCFile = {
+  /** name of the file */
+  name: string;
+} & (
+  | {
+      /** blob, also accepts types that inherit Blob, like File */
+      blob: Blob;
     }
+  | {
+      /** base64 encoded file data */
+      base64: string;
+    }
+  | {
+      /** text for textfile, will be encoded as utf8 */
+      plainText: string;
+    }
+);
+
+type sendOptions =
+  | {
+      file: XDCFile;
+      text?: string;
+    }
+  | {
+      file?: XDCFile;
+      text: string;
+    };
+
+interface Webxdc<T> {
+  /** Returns the peer's own address.
+   *  This is esp. useful if you want to differ between different peers - just send the address along with the payload,
+   *  and, if needed, compare the payload addresses against selfAddr() later on. */
+  selfAddr: string;
+  /** Returns the peer's own name. This is name chosen by the user in their settings, if there is nothing set, that defaults to the peer's address. */
+  selfName: string;
+  /**
+   * set a listener for new status updates.
+   * The "serial" specifies the last serial that you know about (defaults to 0).
+   * Note that own status updates, that you send with {@link sendUpdate}, also trigger this method
+   * @returns promise that resolves when the listener has processed all the update messages known at the time when `setUpdateListener` was called.
+   * */
+  setUpdateListener(
+    cb: (statusUpdate: ReceivedStatusUpdate<T>) => void,
+    serial?: number
+  ): Promise<void>;
+  /**
+   * @deprecated See {@link setUpdateListener|`setUpdateListener()`}.
+   */
+  getAllUpdates(): Promise<ReceivedStatusUpdate<T>[]>;
+  /**
+   * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
+   * @param update status update to send
+   * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
+   */
+  sendUpdate(update: SendingStatusUpdate<T>, description: string): void;
+  /**
+   * Send a message with file, text or both to a chat.
+   * Asks user to what Chat to send the message to.
+   * Always exits the xdc, please save your app state before calling this function
+   * @param content
+   * @returns returns a promise that never resolves (because the xdc closes), but is rejected on error.
+   */
+  sendToChat(content: sendOptions): Promise<void>;
+  /**
+   * TODO
+   */
+  importFiles(filters: {
+    mimeTypes?: string[];
+    extentions?: string[];
+    /** false by default, whether to allow multiple files to be selected */
+    multiple?: boolean;
+  }): Promise<File[]>;
+}
+
+////////// ANCHOR: global
+declare global {
+  interface Window {
+    webxdc: Webxdc<any>;
   }
-  ////////// ANCHOR_END: global
-  
-  export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc };
-  
+}
+////////// ANCHOR_END: global
+
+export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc, XDCFile };

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -34,7 +34,7 @@ type ReceivedStatusUpdate<T> = {
   summary?: string;
 };
 
-export type XDCFile = {
+type XDCFile = {
   /** name of the file */
   name: string;
 } & (
@@ -97,15 +97,6 @@ interface Webxdc<T> {
    * @returns returns a promise that never resolves (because the xdc closes), but is rejected on error.
    */
   sendToChat(content: sendOptions): Promise<void>;
-  /**
-   * TODO
-   */
-  importFiles(filters: {
-    mimeTypes?: string[];
-    extentions?: string[];
-    /** false by default, whether to allow multiple files to be selected */
-    multiple?: boolean;
-  }): Promise<File[]>;
 }
 
 ////////// ANCHOR: global
@@ -117,3 +108,12 @@ declare global {
 ////////// ANCHOR_END: global
 
 export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc, XDCFile };
+
+/* Types for the Simulator */
+declare global {
+  interface Window {
+    addXdcPeer: () => void;
+    clearXdcStorage: () => void;
+    alterXdcApp: () => void;
+  }
+}

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -72,11 +72,13 @@ type SendingStatusUpdate<T> = {
      */
     sendUpdate(update: SendingStatusUpdate<T>, description: string): void;
     /**
-     * TODO
+     * Send a message with file, text or both to a chat.
+     * Asks user to what Chat to send the message to.
+     * Always exits the xdc, please save your app state before calling this function
      * @param content
-     * @returns returns a promise that is resolved to true once export is completed or false on error/abort
+     * @returns returns a promise that never resolves (because the xdc closes), but is rejected on error.
      */
-    sendToChat(content: sendOptions): Promise<boolean>;
+    sendToChat(content: sendOptions): Promise<void>;
     /**
      * TODO
      */

--- a/webxdc.d.ts
+++ b/webxdc.d.ts
@@ -1,0 +1,100 @@
+//@ts-check
+
+type SendingStatusUpdate<T> = {
+    /** the payload, deserialized json:
+     * any javascript primitive, array or object. */
+    payload: T;
+    /** optional, short, informational message that will be added to the chat,
+     * eg. "Alice voted" or "Bob scored 123 in MyGame";
+     * usually only one line of text is shown,
+     * use this option sparingly to not spam the chat. */
+    info?: string;
+    /** optional, if the Webxdc creates a document, you can set this to the name of the document;
+     * do not set if the Webxdc does not create a document */
+    document?: string;
+    /** optional, short text, shown beside the icon;
+     * it is recommended to use some aggregated value,
+     * eg. "8 votes", "Highscore: 123" */
+    summary?: string;
+  };
+  
+  type ReceivedStatusUpdate<T> = {
+    /** the payload, deserialized json */
+    payload: T;
+    /** the serial number of this update. Serials are larger than 0 and newer serials have higher numbers */
+    serial: number;
+    /** the maximum serial currently known */
+    max_serial: number;
+    /** optional, short, informational message. */
+    info?: string;
+    /** optional, if the Webxdc creates a document, this is the name of the document;
+     * not set if the Webxdc does not create a document */
+    document?: string;
+    /** optional, short text, shown beside the webxdc's icon. */
+    summary?: string;
+  };
+  
+  type sendOptions =
+    | {
+        file: File;
+        text?: string;
+      }
+    | {
+        file?: File;
+        text: string;
+      };
+  
+  interface Webxdc<T> {
+    /** Returns the peer's own address.
+     *  This is esp. useful if you want to differ between different peers - just send the address along with the payload,
+     *  and, if needed, compare the payload addresses against selfAddr() later on. */
+    selfAddr: string;
+    /** Returns the peer's own name. This is name chosen by the user in their settings, if there is nothing set, that defaults to the peer's address. */
+    selfName: string;
+    /**
+     * set a listener for new status updates.
+     * The "serial" specifies the last serial that you know about (defaults to 0).
+     * Note that own status updates, that you send with {@link sendUpdate}, also trigger this method
+     * @returns promise that resolves when the listener has processed all the update messages known at the time when `setUpdateListener` was called.
+     * */
+    setUpdateListener(
+      cb: (statusUpdate: ReceivedStatusUpdate<T>) => void,
+      serial?: number
+    ): Promise<void>;
+    /**
+     * @deprecated See {@link setUpdateListener|`setUpdateListener()`}.
+     */
+    getAllUpdates(): Promise<ReceivedStatusUpdate<T>[]>;
+    /**
+     * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
+     * @param update status update to send
+     * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
+     */
+    sendUpdate(update: SendingStatusUpdate<T>, description: string): void;
+    /**
+     * TODO
+     * @param content
+     * @returns returns a promise that is resolved to true once export is completed or false on error/abort
+     */
+    sendToChat(content: sendOptions): Promise<boolean>;
+    /**
+     * TODO
+     */
+    importFiles(filters: {
+      mimeTypes?: string[];
+      extentions?: string[];
+      /** false by default, whether to allow multiple files to be selected */
+      multiple?: boolean;
+    }): Promise<File[]>;
+  }
+  
+  ////////// ANCHOR: global
+  declare global {
+    interface Window {
+      webxdc: Webxdc<any>;
+    }
+  }
+  ////////// ANCHOR_END: global
+  
+  export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc };
+  

--- a/webxdc.js
+++ b/webxdc.js
@@ -60,7 +60,7 @@ window.webxdc = (() => {
               );
             }
             const confirmed = confirm(
-              `now the user would select a chat to send this message. (the user can also abort then the sendToChat promise resolves with false):\n${JSON.stringify(
+              `now app would close and the user would select a chat to send this message.:\n${JSON.stringify(
                 content
               )}`
             );
@@ -87,9 +87,6 @@ window.webxdc = (() => {
                 element.click();
                 document.body.removeChild(element);
               }
-              return Promise.resolve(true);
-            } else {
-              return Promise.resolve(false);
             }
         },
         importFiles: (filters) => {

--- a/webxdc.js
+++ b/webxdc.js
@@ -60,7 +60,7 @@ window.webxdc = (() => {
               );
             }
             const confirmed = confirm(
-              `now app would close and the user would select a chat to send this message.:\n${JSON.stringify(
+              `The app would now close and the user would select a chat to send this message:\n${JSON.stringify(
                 content
               )}`
             );

--- a/webxdc.js
+++ b/webxdc.js
@@ -59,11 +59,6 @@ window.webxdc = (() => {
                 "Error from sendToChat: either file or text need to be set"
               );
             }
-            const confirmed = confirm(
-              `The app would now close and the user would select a chat to send this message:\n${JSON.stringify(
-                content
-              )}`
-            );
 
             /** @type {(file: Blob) => Promise<string>} */
             const blob_to_base64 = (file) => {
@@ -83,51 +78,60 @@ window.webxdc = (() => {
               });
             };
 
-            if (confirmed) {
-              if (content.file) {
-                if (!content.file.name) {
-                  return Promise.reject("file name is missing");
-                }
-                if (
-                  Object.keys(content.file).filter((key) =>
-                    ["blob", "base64", "plainText"].includes(key)
-                  ).length > 1
-                ) {
-                  return Promise.reject(
-                    "you can only set one of `blob`, `base64` or `plainText`, not multiple ones"
-                  );
-                }
-                let base64Content;
-                // @ts-ignore - needed because typescript imagines that blob would not exist
-                if (content.file.blob instanceof Blob) {
-                  // @ts-ignore - needed because typescript imagines that blob would not exist
-                  base64Content = await blob_to_base64(content.file.blob);
-                  // @ts-ignore - needed because typescript imagines that base64 would not exist
-                } else if (typeof content.file.base64 === "string") {
-                  // @ts-ignore - needed because typescript imagines that base64 would not exist
-                  base64Content = content.file.base64;
-                  // @ts-ignore - needed because typescript imagines that plainText would not exist
-                } else if (typeof content.file.plainText === "string") {
-                  base64Content = await blob_to_base64(
-                    // @ts-ignore - needed because typescript imagines that plainText would not exist
-                    new Blob([content.file.plainText])
-                  );
-                } else {
-                  return Promise.reject(
-                    "data is not set or wrong format, set one of `blob`, `base64` or `plainText`, see webxdc documentation for sendToChat"
-                  );
-                }
-
-                var element = document.createElement("a");
-                element.setAttribute(
-                  "href",
-                  "data:application/octet-stream;base64," + base64Content
-                );
-                element.setAttribute("download", content.file.name);
-                document.body.appendChild(element);
-                element.click();
-                document.body.removeChild(element);
+            let base64Content;
+            if (content.file) {
+              if (!content.file.name) {
+                return Promise.reject("file name is missing");
               }
+              if (
+                Object.keys(content.file).filter((key) =>
+                  ["blob", "base64", "plainText"].includes(key)
+                ).length > 1
+              ) {
+                return Promise.reject(
+                  "you can only set one of `blob`, `base64` or `plainText`, not multiple ones"
+                );
+              }
+
+              // @ts-ignore - needed because typescript imagines that blob would not exist
+              if (content.file.blob instanceof Blob) {
+                // @ts-ignore - needed because typescript imagines that blob would not exist
+                base64Content = await blob_to_base64(content.file.blob);
+                // @ts-ignore - needed because typescript imagines that base64 would not exist
+              } else if (typeof content.file.base64 === "string") {
+                // @ts-ignore - needed because typescript imagines that base64 would not exist
+                base64Content = content.file.base64;
+                // @ts-ignore - needed because typescript imagines that plainText would not exist
+              } else if (typeof content.file.plainText === "string") {
+                base64Content = await blob_to_base64(
+                  // @ts-ignore - needed because typescript imagines that plainText would not exist
+                  new Blob([content.file.plainText])
+                );
+              } else {
+                return Promise.reject(
+                  "data is not set or wrong format, set one of `blob`, `base64` or `plainText`, see webxdc documentation for sendToChat"
+                );
+              }
+            }
+            const confirmed = confirm(
+              `The app would now close and the user would select a chat to send this message:\nText: ${
+                content.text ? `"${content.text}"` : "No Text"
+              }\nFile: ${
+                content.file
+                  ? `${content.file.name} - ${base64Content.length} bytes`
+                  : "No File"
+              }`
+            );
+            if (confirmed && content.file) {
+              var element = document.createElement("a");
+              element.setAttribute(
+                "href",
+                "data:application/octet-stream;base64," + base64Content
+              );
+              element.setAttribute("download", content.file.name);
+              document.body.appendChild(element);
+              element.click();
+              document.body.removeChild(element);
             }
         },
         importFiles: (filters) => {

--- a/webxdc.js
+++ b/webxdc.js
@@ -1,6 +1,6 @@
 // debug friend: document.writeln(JSON.stringify(value));
 //@ts-check
-/** @type {import('./webxdc.d').Webxdc<any>} */
+/** @type {import('./webxdc').Webxdc<any>} */
 window.webxdc = (() => {
     var updateListener = (_) => {};
     var updatesKey = "__xdcUpdatesKey__";
@@ -22,8 +22,7 @@ window.webxdc = (() => {
     }
 
     var params = new URLSearchParams(window.location.hash.substr(1));
-    /** @type {import('./webxdc.d').Webxdc<any>} */
-    const webxdc =  {
+    return {
         selfAddr: params.get("addr") || "device0@local.host",
         selfName: params.get("name") || "device0",
         setUpdateListener: (cb, serial = 0) => {
@@ -113,53 +112,31 @@ window.webxdc = (() => {
                 );
               }
             }
-            const confirmed = confirm(
-              `The app would now close and the user would select a chat to send this message:\nText: ${
+            const msg = `The app would now close and the user would select a chat to send this message:\nText: ${
                 content.text ? `"${content.text}"` : "No Text"
               }\nFile: ${
-                content.file
-                  ? `${content.file.name} - ${base64Content.length} bytes`
-                  : "No File"
-              }`
-            );
-            if (confirmed && content.file) {
-              var element = document.createElement("a");
-              element.setAttribute(
-                "href",
-                "data:application/octet-stream;base64," + base64Content
-              );
-              element.setAttribute("download", content.file.name);
-              document.body.appendChild(element);
-              element.click();
-              document.body.removeChild(element);
-            }
-        },
-        importFiles: (filters) => {
-            var element = document.createElement("input");
-            element.type = "file";
-            element.accept = [...filters.extentions, ...filters.mimeTypes].join(
-              ","
-            );
-            element.multiple = filters.multiple || false;
-            const promise = new Promise((resolve, _reject) => {
-              element.onchange = (_ev) => {
-                console.log("element.files", element.files);
-                const files = [...element.files];
+                content.file ? `${content.file.name} - ${base64Content.length} bytes` : "No File"
+              }`;
+            if (content.file) {
+              const confirmed = confirm(msg + '\n\nDownload the file in the browser instead?');
+              if (confirmed) {
+                var element = document.createElement("a");
+                element.setAttribute(
+                  "href",
+                  "data:application/octet-stream;base64," + base64Content
+                );
+                element.setAttribute("download", content.file.name);
+                document.body.appendChild(element);
+                element.click();
                 document.body.removeChild(element);
-                resolve(files);
-              };
-            });
-            // element.style.display = "none"
-            document.body.appendChild(element);
-            element.click();
-            console.log(element);
-            return promise;
+              }
+            } else {
+              alert(msg);
+            }
         }
     };
-    return webxdc
 })();
 
-//@ts-ignore
 window.addXdcPeer = () => {
     var loc = window.location;
     // get next peer ID
@@ -175,12 +152,12 @@ window.addXdcPeer = () => {
     params.set("next_peer", String(peerId + 1));
     window.location.hash = "#" + params.toString();
 }
-//@ts-ignore
+
 window.clearXdcStorage = () => {
     window.localStorage.clear();
     window.location.reload();
 }
-//@ts-ignore
+
 window.alterXdcApp = () => {
     var styleControlPanel = 'position: fixed; bottom:1em; left:1em; background-color: #000; opacity:0.8; padding:.5em; font-size:16px; font-family: sans-serif; color:#fff; z-index: 9999';
     var styleMenuLink = 'color:#fff; text-decoration: none; vertical-align: middle';
@@ -216,5 +193,5 @@ window.alterXdcApp = () => {
         document.getElementsByTagName('body')[0].append(controlPanel);
     }
 }
-//@ts-ignore
+
 window.addEventListener("load", window.alterXdcApp);

--- a/webxdc.js
+++ b/webxdc.js
@@ -75,13 +75,7 @@ window.webxdc = (() => {
                     reader.onload = () => resolve(reader.result);
                     reader.onerror = () => reject(reader.error);
                   }))();
-                element.setAttribute(
-                  "href",
-                  "data:" +
-                    (content.file.type || "application/octet-stream") +
-                    ";base64;" +
-                    base64Content
-                );
+                element.setAttribute("href", base64Content);
                 element.setAttribute("download", content.file.name);
                 document.body.appendChild(element);
                 element.click();

--- a/webxdc.js
+++ b/webxdc.js
@@ -94,19 +94,25 @@ window.webxdc = (() => {
         },
         importFiles: (filters) => {
             // simon: please don't copy this hacky code for android
-            return new Promise((resolve, reject)=>{
-                var element = document.createElement("input");
-                element.accept = [...filters.extentions, ...filters.mimeTypes].join(',')
-                element.multiple = filters.multiple || false
-                element.onchange = (ev)=>{
-                    console.log("element.files", element.files)
-                    const files = [...element.files]
-                    document.body.removeChild(element);
-                    resolve(files)
-                }
-                element.style.display="none"
-                element.click()
-            })
+            var element = document.createElement("input");
+            element.type = "file";
+            element.accept = [...filters.extentions, ...filters.mimeTypes].join(
+              ","
+            );
+            element.multiple = filters.multiple || false;
+            const promise = new Promise((resolve, _reject) => {
+              element.onchange = (_ev) => {
+                console.log("element.files", element.files);
+                const files = [...element.files];
+                document.body.removeChild(element);
+                resolve(files);
+              };
+            });
+            // element.style.display = "none"
+            document.body.appendChild(element);
+            element.click();
+            console.log(element);
+            return promise;
         }
     };
     return webxdc


### PR DESCRIPTION
- re-enable global import export fix export (line breaks were missing when copying)
- export to file also add types
- import from file

- [X] change to new iteration of the api 

- fixes #8

Serves as an example implementation for the webxdc `importFiles` and `sendToChat` apis. Already works in the simulator.

Needs both apis:
- https://github.com/webxdc/webxdc_docs/pull/44
- https://github.com/webxdc/webxdc_docs/pull/50